### PR TITLE
Update to the latest version of mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": "fs-utils/mkdirp-then",
   "dependencies": {
-    "mkdirp": "0",
+    "mkdirp": "^0.5.0",
     "native-or-bluebird": "1"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes #2

With NPM3's flat folder structure, if another dependency in your project
is using an older version of mkdirp, it will be used instead of the
latest version since if it is still semver compatible with `"0"`. This
was not a problem in NPM2 which always installed a local copy in
mkdirp-then's node_modules.
